### PR TITLE
feat: Add custom headers to webhooks

### DIFF
--- a/src/models/webhook_config.py
+++ b/src/models/webhook_config.py
@@ -12,6 +12,7 @@ class WebhookConfig(db.Model):
     url = db.Column(db.String(500), nullable=False)
     input_fields = db.Column(db.Text)  # JSON string of field definitions
     output_fields = db.Column(db.Text)  # JSON string of field definitions
+    headers = db.Column(db.Text)  # JSON string of headers
     is_active = db.Column(db.Boolean, default=True)
     created_timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     updated_timestamp = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -25,6 +26,7 @@ class WebhookConfig(db.Model):
             'url': self.url,
             'input_fields': self.input_fields,
             'output_fields': self.output_fields,
+            'headers': self.headers,
             'is_active': self.is_active,
             'created_timestamp': self.created_timestamp.isoformat() if self.created_timestamp else None,
             'updated_timestamp': self.updated_timestamp.isoformat() if self.updated_timestamp else None

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -50,6 +50,12 @@ def create_webhook():
             except json.JSONDecodeError:
                 return jsonify({'error': 'Invalid JSON format for output fields'}), 400
         
+        if data.get('headers'):
+            try:
+                json.loads(data['headers'])
+            except json.JSONDecodeError:
+                return jsonify({'error': 'Invalid JSON format for headers'}), 400
+
         webhook = WebhookConfig(
             webhook_id=str(uuid.uuid4()),
             name=data['name'],
@@ -58,6 +64,7 @@ def create_webhook():
             url=data['url'],
             input_fields=data.get('input_fields', ''),
             output_fields=data.get('output_fields', ''),
+            headers=data.get('headers', ''),
             is_active=data.get('is_active', True)
         )
         
@@ -96,6 +103,12 @@ def update_webhook(webhook_id):
             except json.JSONDecodeError:
                 return jsonify({'error': 'Invalid JSON format for output fields'}), 400
         
+        if data.get('headers'):
+            try:
+                json.loads(data['headers'])
+            except json.JSONDecodeError:
+                return jsonify({'error': 'Invalid JSON format for headers'}), 400
+
         # Update fields
         if 'name' in data:
             webhook.name = data['name']
@@ -111,6 +124,8 @@ def update_webhook(webhook_id):
             webhook.input_fields = data['input_fields']
         if 'output_fields' in data:
             webhook.output_fields = data['output_fields']
+        if 'headers' in data:
+            webhook.headers = data['headers']
         if 'is_active' in data:
             webhook.is_active = data['is_active']
         

--- a/src/routes/verification.py
+++ b/src/routes/verification.py
@@ -82,13 +82,23 @@ def run_verification():
             
             webhook_data['contacts'].append(contact_data)
         
+        # Prepare headers for the webhook
+        headers = {'Content-Type': 'application/json'}
+        if webhook.headers:
+            try:
+                custom_headers = json.loads(webhook.headers)
+                headers.update(custom_headers)
+            except json.JSONDecodeError:
+                # Log the error or handle it as needed
+                pass
+
         # Send webhook to Make.com (async in production)
         try:
             response = requests.post(
                 webhook.url,
                 json=webhook_data,
                 timeout=30,
-                headers={'Content-Type': 'application/json'}
+                headers=headers
             )
             
             if response.status_code == 200:


### PR DESCRIPTION
This change adds the ability to specify custom headers for webhooks.

- The `WebhookConfig` model has been updated to include a `headers` field.
- The `run_verification` function now uses these custom headers when sending requests to make.com.
- The settings page has been updated to allow you to add and edit custom headers for webhooks.