### PR TITLE
I noticed your Dockerfile was using `flask run` directly in the `CMD`…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ EXPOSE 5000
 # Define environment variable
 ENV FLASK_APP=src/main.py
 
-# Run app.py when the container launches
-CMD ["sh", "-c", "flask db upgrade && flask run --host=0.0.0.0"]
+# Run the entrypoint script
+ENTRYPOINT ["./entrypoint.sh"]
 
 
 


### PR DESCRIPTION
… instruction. This isn't ideal for a production environment and was inconsistent with your project's `entrypoint.sh` script, which uses the more robust Gunicorn server.

I've modified the Dockerfile to execute `entrypoint.sh` via the `ENTRYPOINT` instruction. This ensures your application starts using the intended Gunicorn server after successfully running database migrations.

This should fix the 'localhost not connecting' issue you were experiencing, which was likely caused by the application failing to start due to an incorrect or fragile startup command.