### PR TITLE
The previous commit introduced a build error by attempting to run `se…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ COPY entrypoint.sh .
 # Make the entrypoint script executable
 RUN chmod +x entrypoint.sh
 
+# Convert CRLF to LF for the entrypoint script
+RUN sed -i 's/\r$//' entrypoint.sh
+
 # Copy the rest of the application's code into the container at /app
 COPY . .
 
@@ -28,8 +31,8 @@ EXPOSE 5000
 # Define environment variable
 ENV FLASK_APP=src/main.py
 
-# Run app.py when the container launches
-CMD ["sh", "-c", "flask db upgrade && flask run --host=0.0.0.0"]
+# Run the entrypoint script
+ENTRYPOINT ["./entrypoint.sh"]
 
 
 

--- a/reset_and_run.sh
+++ b/reset_and_run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# This script resets the application environment by stopping containers,
+# deleting the database, and rebuilding and restarting the services.
+
+echo "Stopping and removing existing Docker containers..."
+docker-compose down
+
+echo "Removing old database file..."
+rm -f data/db/app.db
+
+echo "Building and starting the application..."
+docker-compose up --build -d
+
+echo "Application is starting. Check 'docker-compose logs -f' for logs."


### PR DESCRIPTION
…d` on `reset_and_run.sh`, which is not present in the Docker build context.

This commit corrects the `Dockerfile` by removing the part of the `RUN` command that references `reset_and_run.sh`. The line-ending conversion is now only applied to `entrypoint.sh`, which is the only script that requires it within the container.

This resolves the Docker build failure.